### PR TITLE
Update GitHub Actions versions in workflow chunks

### DIFF
--- a/userpatches-jethub/gha/chunks/050.single_header.yaml
+++ b/userpatches-jethub/gha/chunks/050.single_header.yaml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Push changes
         if: ${{ github.event.inputs.skip_version_bump != 'true' }}
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v1
         with:
           github_token: ${{ env.GH_TOKEN }}
           repository: ${{ github.repository }}
@@ -175,7 +175,7 @@ jobs:
           echo ${VER}.jh.${SUBVER} > downloads/version
 
       - name: 'Upload Artifact'
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v6
         with:
           name: assets-for-download-[[repository_ref]]
           path: downloads
@@ -275,7 +275,7 @@ jobs:
 
       - name: GitHub cache
         id: cache-restore
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             cache/memoize
@@ -324,7 +324,7 @@ jobs:
           echo "Logs: ${{ steps.prepare-matrix.outputs.logs_url }}"
 
       # Store output/info folder in a GitHub Actions artifact
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@v6
         name: Upload output/info as GitHub Artifact
         with:
           name: build-info-json

--- a/userpatches-jethub/gha/chunks/750.single_repo.yaml
+++ b/userpatches-jethub/gha/chunks/750.single_repo.yaml
@@ -74,7 +74,7 @@ jobs: # <TEMPLATE-IGNORE>
 
       # Download the artifacts (output/info) produced by the prepare-matrix job.
       - name: Download artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: build-info-json
           path: output/info

--- a/userpatches-jethub/gha/chunks/950.single_footer.yaml
+++ b/userpatches-jethub/gha/chunks/950.single_footer.yaml
@@ -11,7 +11,7 @@ jobs: # <TEMPLATE-IGNORE>
     steps:
       - name: "Download all workflow run artifacts"
         if: ${{ (github.event.inputs.skipImages || [[skipImagesDefaults]]) != 'yes' }}
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v7
         with:
           name: assets-for-download-[[repository_ref]]
           path: downloads


### PR DESCRIPTION
Updated the following actions to their latest stable versions in userpatches-jethub/gha/chunks/:
- actions/upload-artifact@v5 -> v6
- actions/download-artifact@v6 -> v7
- actions/cache@v4 -> v5
- ad-m/github-push-action@master -> v1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Modernizes CI by upgrading key GitHub Actions to current stable tags across `userpatches-jethub/gha/chunks`.
> 
> - Bump `ad-m/github-push-action` from `master` to `v1`
> - Bump `actions/upload-artifact` from `v5` to `v6` (multiple steps)
> - Bump `actions/download-artifact` from `v6` to `v7` (multiple steps)
> - Bump `actions/cache` from `v4` to `v5`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c388ee5e68c3a699e31e7c8edc3140bccaaec19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->